### PR TITLE
Move revalidate settings to fetch()

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,6 @@ import SectionQuotes from "../components/SectionQuotes";
 import Header from "../components/Header";
 import { Metadata } from "next";
 
-export const revalidate = 60 * 30;
-
 export const metadata: Metadata = {
   title: "Scoreboarder: Keep track of scoreboards on Discord with ease",
   description:

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ async function fetchTopGGStats() {
         Authorization: process.env.TOPGG_TOKEN,
       },
       next: {
-        revalidate: 60 * 5,
+        revalidate: 300,
       },
     }
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,9 @@ async function fetchTopGGStats() {
         Accept: "application/json",
         Authorization: process.env.TOPGG_TOKEN,
       },
+      next: {
+        revalidate: 60 * 5,
+      },
     }
   );
 

--- a/components/SectionUpcomingFeatures.tsx
+++ b/components/SectionUpcomingFeatures.tsx
@@ -17,6 +17,9 @@ async function fetchGithubIssues() {
     {
       method: "GET",
       headers: { Accept: "application/vnd.github.v3+json" },
+      next: {
+        revalidate: 60 * 20,
+      },
     }
   );
 

--- a/components/SectionUpcomingFeatures.tsx
+++ b/components/SectionUpcomingFeatures.tsx
@@ -18,7 +18,7 @@ async function fetchGithubIssues() {
       method: "GET",
       headers: { Accept: "application/vnd.github.v3+json" },
       next: {
-        revalidate: 60 * 20,
+        revalidate: 1200,
       },
     }
   );


### PR DESCRIPTION
Instead of keeping them at the page level, we can specify them on each fetch() call, allowing more flexbility in chacing times.

Fixes WEB-11